### PR TITLE
Use equals instead of ok for hasOwnProperty. 

### DIFF
--- a/topics/about_reflection.js
+++ b/topics/about_reflection.js
@@ -1,4 +1,3 @@
-
 module("About Reflection (topics/about_reflection.js)");
 
 test("typeof", function() {
@@ -29,7 +28,7 @@ test("hasOwnProperty", function() {
     for(propertyName in fruits) {
         keys.push(propertyName);
     }
-    ok(keys.equalTo(['__', '__', '__']), 'what are the properties of the array?');
+    equals(['__', '__', '__'], keys, 'what are the properties of the array?')
 
     var ownKeys = [];
     for(propertyName in fruits) {


### PR DESCRIPTION
Use equals instead of ok for hasOwnProperty. I found it pretty mysterious, and this helps provide a hint, and I think works better pedagogically.
