### PR TITLE
fixed assertion in about_functions_and_closure.js

### DIFF
--- a/topics/about_functions_and_closure.js
+++ b/topics/about_functions_and_closure.js
@@ -25,12 +25,12 @@ test("self invoking functions", function() {
     (function(pv) {
         var secretValue = "password";
         equals(pv, __, 'what is the value of pv?');
-        equals(typeof(secretValue), "__", "is secret value available in this context?");
-        equals(typeof(pv), "__", "is public value available in this context?");
+        equals(typeof(secretValue), "__", "is secretValue available in this context?");
+        equals(typeof(publicValue), "__", "is publicValue available in this context?");
     })(publicValue);
 
-    equals(typeof(secretValue), "__", "is secret value available in this context?");
-    equals(typeof(publicValue), "__", "is public value available in this context?");
+    equals(typeof(secretValue), "__", "is secretValue available in this context?");
+    equals(typeof(publicValue), "__", "is publicValue available in this context?");
 });
 
 test("arguments array", function() {


### PR DESCRIPTION
The variable which should be tested is publicValue, not pv, because the koan teaches variable scope rules. In this context, it doesn't make sense to test pv rather than publicValue.
