### PR TITLE
Explicitly declare for..in vars

### DIFF
--- a/topics/about_control_structures.js
+++ b/topics/about_control_structures.js
@@ -24,7 +24,7 @@ test("for in", function() {
 	};
 	var result = "";
 	// for in enumerates the property names of an object
-	for (property_name in person) {
+	for (var property_name in person) {
   result = result + property_name;
 	};
 	equals(result, __, 'what is the value of result?');

--- a/topics/about_reflection.js
+++ b/topics/about_reflection.js
@@ -21,7 +21,7 @@ test("property enumeration", function() {
     var keys = [];
     var values = [];
     var person = {name: 'Amory Blaine', age: 102, unemployed: true};
-    for(propertyName in person) {
+    for(var propertyName in person) {
         keys.push(propertyName);
         values.push(person[propertyName]);
     }
@@ -31,6 +31,7 @@ test("property enumeration", function() {
 
 test("hasOwnProperty", function() {
     var b = new B();
+    var propertyName;
 
     var keys = [];
     for (propertyName in b) {


### PR DESCRIPTION
If there isn't an explicit `var` declaration for loop variables, a global variable is created.  It doesn't make a difference for these examples, but since the koans are for learning it's probably a good idea to get people in the habit of explicitly declaring variables.
