### PR TITLE
Automatically scroll to the bottom.

### DIFF
--- a/support/koans.js
+++ b/support/koans.js
@@ -56,6 +56,7 @@ Array.prototype.equalTo = function(compareTo) {
 		if (failures > 0) {
 			$("#zen-help").show();
 		}
+		$("body").scrollTop($(document).height());
 	});
 
 	QUnit.log(function(result) {


### PR DESCRIPTION
I think it is a little troublesome to scroll to the bottom every time to see the failing case. This PR automatically scrolls to the bottom of the page after the tests run.