### PR TITLE
Cleanup using airbnb style guide

### DIFF
--- a/topics/about_arrays.js
+++ b/topics/about_arrays.js
@@ -1,45 +1,49 @@
-module("About Arrays (topics/about_arrays.js)");
+module('About Arrays (topics/about_arrays.js)');
 
-test("array literal syntax and indexing", function() {
-    var favouriteThings = ["cellar door", 42, true]; // note that array elements do not have to be of the same type
-    equal(__, favouriteThings[0], 'what is in the first position of the array?');
-    equal(__, favouriteThings[1], 'what is in the second position of the array?');
-    equal(__, favouriteThings[2], 'what is in the third position of the array?');
+test('array literal syntax and indexing', function () {
+  // note that array elements do not have to be of the same type
+  var favouriteThings = ['cellar door', 42, true];
+
+  equal(__, favouriteThings[0], 'what is in the first position of the array?');
+  equal(__, favouriteThings[1], 'what is in the second position of the array?');
+  equal(__, favouriteThings[2], 'what is in the third position of the array?');
 });
 
-test("array type", function() {
-    equal(__, typeof([]), 'what is the type of an array?');
+test('array type', function () {
+  equal(__, typeof ([]), 'what is the type of an array?');
 });
 
-test("length", function() {
-    var collection = ['a','b','c'];
-    equal(__, collection.length, 'what is the length of the collection array?');
+test('length', function () {
+  var collection = ['a', 'b', 'c'];
+
+  equal(__, collection.length, 'what is the length of the collection array?');
 });
 
-test("splice", function() {
-    var daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
-    var workingWeek = daysOfWeek.splice(__, __);
-    var weekend = daysOfWeek;
+test('splice', function () {
+  var daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+  var workingWeek = daysOfWeek.splice(__, __);
+  var weekend = daysOfWeek;
 
-    deepEqual(workingWeek, ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], 'what is the value of workingWeek?');
-    deepEqual(weekend, ['Saturday', 'Sunday'], 'what is the value of weekend?');
+  deepEqual(workingWeek, ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+    'what is the value of workingWeek?');
+  deepEqual(weekend, ['Saturday', 'Sunday'], 'what is the value of weekend?');
 });
 
-test("stack methods", function() {
-    var stack = [];
-    stack.push("first");
-    stack.push("second");
+test('stack methods', function () {
+  var stack = [];
+  stack.push('first');
+  stack.push('second');
 
-    equal(__, stack.pop(), 'what will be the first value popped off the stack?');
-    equal(__, stack.pop(), 'what will be the second value popped off the stack?');
+  equal(__, stack.pop(), 'what will be the first value popped off the stack?');
+  equal(__, stack.pop(), 'what will be the second value popped off the stack?');
 });
 
-test("queue methods", function() {
-    var queue = [];
-    queue.push("first");
-    queue.push("second");
-    queue.unshift("third");
+test('queue methods', function () {
+  var queue = [];
+  queue.push('first');
+  queue.push('second');
+  queue.unshift('third');
 
-    equal(__, queue.shift(), 'what will be shifted out first?');
-    equal(__, queue.shift(), 'what will be shifted out second?');
+  equal(__, queue.shift(), 'what will be shifted out first?');
+  equal(__, queue.shift(), 'what will be shifted out second?');
 });

--- a/topics/about_asserts.js
+++ b/topics/about_asserts.js
@@ -1,14 +1,13 @@
+module('About Asserts (topics/about_asserts.js)');
 
-module("About Asserts (topics/about_asserts.js)");
-
-test("ok", function() {
-    ok(__ === true, 'what will satisfy the ok assertion?');
+test('ok', function () {
+  ok(__ === true, 'what will satisfy the ok assertion?');
 });
 
-test("not ok", function() {
-    ok(__ === false, 'what is a false value?');
+test('not ok', function () {
+  ok(__ === false, 'what is a false value?');
 });
 
-test("equal", function() {
-    equal(__, 1 + 1, 'what will satisfy the equal assertion?');
+test('equal', function () {
+  equal(__, 1 + 1, 'what will satisfy the equal assertion?');
 });

--- a/topics/about_assignment.js
+++ b/topics/about_assignment.js
@@ -1,12 +1,13 @@
+module('About Assignment (topics/about_assignment.js)');
 
-module("About Assignment (topics/about_assignment.js)");
+test('local variables', function () {
+  var temp = __;
 
-test("local variables", function() {
-    var temp = __;
-    equal(temp, 1, "Assign a value to the variable temp");
+  equal(temp, 1, 'Assign a value to the variable temp');
 });
 
-test("global variables", function() {
-    temp = 1; // Not using var is an example. Always use var in practise.
-    equal(window.__, temp, 'global variables are assigned to the window object');
+test('global variables', function () {
+  temp = 1; // Not using var is an example. Always use var in practise.
+
+  equal(window.__, temp, 'global variables are assigned to the window object');
 });

--- a/topics/about_control_structures.js
+++ b/topics/about_control_structures.js
@@ -1,73 +1,88 @@
-module("About Control Structures (topics/about_control_structures.js)");
+module('About Control Structures (topics/about_control_structures.js)');
 
-test("if", function() {
-	var isPositive = false;
-	if (2 > 0) {
-		isPositive = true;
-	}
-	equal(__, isPositive,  'what is the value of isPositive?');
+test('if', function () {
+  var isPositive = false;
+  if (2 > 0) {
+    isPositive = true;
+  }
+
+  equal(__, isPositive, 'what is the value of isPositive?');
 });
 
-test("for", function() {
-	var counter = 10;
-	for (var i = 1; i <= 3; i++) {
-		counter = counter + i;
-	}
-	equal(__, counter, 'what is the value of counter?');
+test('for', function () {
+  var counter = 10;
+  for (var i = 1; i <= 3; i++) {
+    counter = counter + i;
+  }
+
+  equal(__, counter, 'what is the value of counter?');
 });
 
-test("for in", function() {
-	// this syntax will be explained in about objects
-	var person = {
-		name: "Amory Blaine",
-		age: 102
-	};
-	var result = "";
-	// for in enumerates the property names of an object
-	for (var property_name in person) {
-  		result = result + property_name;
-	}
-	equal(__, result, 'what is the value of result?');
+test('for in', function () {
+  // this syntax will be explained in about objects
+  var person = {
+    name: 'Amory Blaine',
+    age: 102,
+  };
+
+  var result = '';
+
+  // for in enumerates the property names of an object
+  for (var propertyName in person) {
+    result = result + propertyName;
+  }
+
+  equal(__, result, 'what is the value of result?');
 });
 
-test("ternary operator", function() {
-	var fruit = true ? "apple" : "orange";
-	equal(__, fruit, 'what is the value of fruit?');
+test('ternary operator', function () {
+  var fruit = true ? 'apple' : 'orange';
+  equal(__, fruit, 'what is the value of fruit?');
 
-	fruit = false ? "apple" : "orange";
-	equal(__, fruit, 'now what is the value of fruit?');
+  fruit = false ? 'apple' : 'orange';
+  equal(__, fruit, 'now what is the value of fruit?');
 });
 
-test("switch", function() {
-	var result = 0;
-	switch (2) {
-		case 1:
-			result = 1;
-			break;
-		case 1+1:
-			result = 2;
-			break;
-	}
-	equal(__, result, 'what is the value of result?');
-});
+test('switch', function () {
+  var result = 0;
 
-test("switch default case", function() {
-    var result = "Pippin";
-    switch ("m") {
-        case "f":
-            result = "Frodo";
-            break;
-        case "s":
-            result = "Samwise";
-                break;
-        default:
-            result = "Merry";
-            break;
+  switch (2) {
+    case 1: {
+      result = 1;
+      break;
     }
-    equal(__, result, 'what is the value of result?');
+    case 1 + 1: {
+      result = 2;
+      break;
+    }
+  }
+
+  equal(__, result, 'what is the value of result?');
 });
 
-test("null coalescing", function() {
-    var result = null || "a value";
-    equal(__, result, 'what is the value of result?');
+test('switch default case', function () {
+  var result = 'Pippin';
+
+  switch ('m') {
+    case 'f': {
+      result = 'Frodo';
+      break;
+    }
+    case 's': {
+      result = 'Samwise';
+      break;
+    }
+    default: {
+      result = 'Merry';
+      break;
+    }
+  }
+
+  equal(__, result, 'what is the value of result?');
+});
+
+test('null coalescing', function () {
+  var result = null || 'a value';
+
+  equal(__, result, 'what is the value of result?');
 });

--- a/topics/about_equality.js
+++ b/topics/about_equality.js
@@ -1,23 +1,22 @@
+module('About Equality (topics/about_equality.js)');
 
-module("About Equality (topics/about_equality.js)");
-
-test("numeric equality", function() {
-    equal(3 + __,  7, "");
+test('numeric equality', function () {
+  equal(3 + __, 7, '');
 });
 
-test("string equality", function() {
-    equal("3" + __, "37", "concatenate the strings");
+test('string equality', function () {
+  equal('3' + __, '37', 'concatenate the strings');
 });
 
-test("equality without type coercion", function() {
-    ok(3 === __, 'what is exactly equal to 3?');
+test('equality without type coercion', function () {
+  ok(__ === 3, 'what is exactly equal to 3?');
 });
 
-test("equality with type coercion", function() {
-    ok(3 == "__", 'what string is equal to 3, with type coercion?');
+test('equality with type coercion', function () {
+  ok(__ == '3', 'what string is equal to 3, with type coercion?');
 });
 
-test("string literals", function() {
-    equal(__, "frankenstein", "quote types are interchangable, but must match.");
-    equal(__, 'frankenstein', "quote types can use both single and double quotes.");
+test('string literals', function () {
+  equal(__, "frankenstein", 'quote types are interchangable, but must match.');
+  equal(__, 'frankenstein', 'quote types can use both single and double quotes.');
 });

--- a/topics/about_functions_and_closure.js
+++ b/topics/about_functions_and_closure.js
@@ -1,75 +1,84 @@
-module("About Functions And Closure (topics/about_functions_and_closure.js)");
+module('About Functions And Closure (topics/about_functions_and_closure.js)');
 
-test("defining functions directly", function() {
-    var result = "a";
-    function changeResult() {
-        // the ability to access a variables defined in the same scope as the function is known as 'closure'
-        result = "b";
-    };
-    changeResult();
-    equal(__, result, 'what is the value of result?');
+test('defining functions directly', function () {
+  var result = 'a';
+
+  // the ability to access a variables defined in the same scope as the function
+  // is known as 'closure'
+  function changeResult() {
+    result = 'b';
+  };
+
+  changeResult();
+
+  equal(__, result, 'what is the value of result?');
 });
 
-test("assigning functions to variables", function() {
-    var triple = function(input) {
-        return input * 3;
-    };
-    equal(__, triple(4), 'what is triple 4?');
+test('assigning functions to variables', function () {
+  var triple = function (input) {
+    return input * 3;
+  };
+
+  equal(__, triple(4), 'what is triple 4?');
 });
 
-test("self invoking functions", function() {
-    var publicValue = "shared";
+test('self invoking functions', function () {
+  var publicValue = 'shared';
 
-    // self invoking functions are used to provide scoping and to alias variables
-    (function(pv) {
-        var secretValue = "password";
-        equal(__, pv, 'what is the value of pv?');
-        equal("__", typeof(secretValue), "is secretValue available in this context?");
-        equal("__", typeof(publicValue), "is publicValue available in this context?");
-    })(publicValue);
+  // self invoking functions are used to provide scoping and to alias variables
+  (function (pv) {
+    var secretValue = 'password';
+    equal(__, pv, 'what is the value of pv?');
+    equal('__', typeof (secretValue), 'is secretValue available in this context?');
+    equal('__', typeof (publicValue), 'is publicValue available in this context?');
+  })(publicValue);
 
-    equal("__", typeof(secretValue), "is secretValue available in this context?");
-    equal("__", typeof(publicValue), "is publicValue available in this context?");
+  equal('__', typeof (secretValue), 'is secretValue available in this context?');
+  equal('__', typeof (publicValue), 'is publicValue available in this context?');
 });
 
-test("arguments array", function() {
-    var add = function() {
-        var total = 0;
-        for(var i = 0; i < arguments.length; i++) {
-            // complete the implementation of this method so that it returns the sum of its arguments
-            // __
-        }
-        // __
-    };
+test('arguments array', function () {
+  var add = function () {
+    var total = 0;
+    for (var i = 0; i < arguments.length; i++) {
 
-    equal(15, add(1,2,3,4,5), "add 1,2,3,4,5");
-    equal(9, add(4,7,-2), "add 4,7,-2");
+      // complete the implementation of this method so that it returns the sum of its arguments
+      // __
+    }
+
+    // __
+  };
+
+  equal(15, add(1, 2, 3, 4, 5), 'add 1,2,3,4,5');
+  equal(9, add(4, 7, -2), 'add 4,7,-2');
 });
 
-test("using call to invoke function",function(){
-    var invokee = function( message ){
-        return this + message;    
-    };
-    
-    //another way to invoke a function is to use the call function which allows 
-    //you to set the callers "this" context.  Call can take any number of arguments: 
-    //the first one is always the context that this should be set to in the called
-    //function, and the arguments to be sent to the function,multiple arguments are separated by commas.
-    var result = invokee.call("I am this!", "Where did it come from?");
-        
-    equal(__, result, "what will the value of invokee's this be?");
+test('using call to invoke function', function () {
+  var invokee = function (message) {
+    return this + message;
+  };
+
+  // another way to invoke a function is to use the call function which allows
+  //   you to set the callers "this" context.
+  // call can take any number of arguments:
+  //   the first one is always the context that this should be set to in the called
+  //   function, and the arguments to be sent to the function, multiple arguments
+  //   are separated by commas.
+  var result = invokee.call('I am this!', 'Where did it come from?');
+
+  equal(__, result, "what will the value of invokee's this be?");
 });
 
-test("using apply to invoke function",function(){
-    var invokee = function( message1, message2 ){
-        return this + message1 + message2;    
-    };
-    
-    //similar to the call function is the apply function.  Apply only has two
-    //arguments:  the first is the context that this should be set to in the called
-    //function and the second is the array of arguments to be passed into the called function.
-    var result = invokee.apply("I am this!", ["I am arg1","I am arg2"]);
-        
-    equal(__, result, "what will the value of invokee's this be?");
-});
+test('using apply to invoke function', function () {
+  var invokee = function (message1, message2) {
+    return this + message1 + message2;
+  };
 
+  // similar to the call function is the apply function. 
+  // apply only has two arguments: 
+  //   the first is the context that this should be set to in the called
+  //   function and the second is the array of arguments to be passed into the called function.
+  var result = invokee.apply('I am this!', ['I am arg1', 'I am arg2']);
+
+  equal(__, result, "what will the value of invokee's this be?");
+});

--- a/topics/about_functions_and_closure.js
+++ b/topics/about_functions_and_closure.js
@@ -74,8 +74,8 @@ test('using apply to invoke function', function () {
     return this + message1 + message2;
   };
 
-  // similar to the call function is the apply function. 
-  // apply only has two arguments: 
+  // similar to the call function is the apply function.
+  // apply only has two arguments:
   //   the first is the context that this should be set to in the called
   //   function and the second is the array of arguments to be passed into the called function.
   var result = invokee.apply('I am this!', ['I am arg1', 'I am arg2']);

--- a/topics/about_numbers.js
+++ b/topics/about_numbers.js
@@ -1,16 +1,17 @@
+module('About Numbers (topics/about_numbers.js)');
 
-module("About Numbers (topics/about_numbers.js)");
+test('types', function () {
+  var typeOfIntegers = typeof (6);
+  var typeOfFloats = typeof (3.14159);
 
-test("types", function() {
-    var typeOfIntegers = typeof(6);
-    var typeOfFloats = typeof(3.14159);
-    equal(__, typeOfIntegers === typeOfFloats, 'are ints and floats the same type?');
-    equal(__, typeOfIntegers, 'what is the javascript numeric type?');
-    equal(__, 1.0, 'what is a integer number equivalent to 1.0?');
+  equal(__, typeOfIntegers === typeOfFloats, 'are ints and floats the same type?');
+  equal(__, typeOfIntegers, 'what is the javascript numeric type?');
+  equal(__, 1.0, 'what is a integer number equivalent to 1.0?');
 });
 
-test("NaN", function() {
-    var resultOfFailedOperations = 7/'apple';
-    equal(__, isNaN(resultOfFailedOperations), 'what will satisfy the equals assertion?');
-    equal(__, resultOfFailedOperations == NaN, 'is NaN == NaN?');
+test('NaN', function () {
+  var resultOfFailedOperations = 7 / 'apple';
+
+  equal(__, isNaN(resultOfFailedOperations), 'what will satisfy the equals assertion?');
+  equal(__, resultOfFailedOperations == NaN, 'is NaN == NaN?');
 });

--- a/topics/about_objects.js
+++ b/topics/about_objects.js
@@ -1,43 +1,48 @@
+module('About Objects (topics/about_objects.js)');
 
-module("About Objects (topics/about_objects.js)");
+test('object type', function () {
+  var emptyObject = {};
 
-test("object type", function() {
-    var empty_object = {};
-    equal(__, typeof(empty_object), 'what is the type of an object?');
+  equal(__, typeof (emptyObject), 'what is the type of an object?');
 });
 
-test("object literal notation", function() {
-    var person = {
-        __:__,
-        __:__
-    };
-    equal("Amory Blaine", person.name, "what is the person's name?");
-    equal(102, person.age, "what is the person's age?");
+test('object literal notation', function () {
+  var person = {
+    __: __,
+    __: __,
+  };
+
+  equal('Amory Blaine', person.name, "what is the person's name?");
+  equal(102, person.age, "what is the person's age?");
 });
 
-test("dynamically adding properties", function() {
-    var person = {};
-    person.__ = "Amory Blaine";
-    person.__ = 102;
-    equal("Amory Blaine", person.name, "what is the person's name?");
-    equal(102, person.age, "what is the person's age?");
-}); 
+test('dynamically adding properties', function () {
+  var person = {};
+  person.__ = 'Amory Blaine';
+  person.__ = 102;
 
-test("adding properties from strings", function() {
-    var person = {};
-    person["__"] = "Amory Blaine";
-    person["__"] = 102;
-    equal("Amory Blaine", person.name, "what is the person's name?");
-    equal(102, person.age, "what is the person's age?");
+  equal('Amory Blaine', person.name, "what is the person's name?");
+  equal(102, person.age, "what is the person's age?");
 });
 
-test("adding functions", function() {
-    var person = {
-        name: "Amory Blaine",
-        age: 102,
-        toString: function() {
-            return __;  // HINT: use the 'this' keyword to refer to the person object.
-        }
-    };
-    equal("I Amory Blaine am 102 years old.", person.toString(), "what should the toString function be?");
+test('adding properties from strings', function () {
+  var person = {};
+  person['__'] = 'Amory Blaine';
+  person['__'] = 102;
+
+  equal('Amory Blaine', person.name, "what is the person's name?");
+  equal(102, person.age, "what is the person's age?");
+});
+
+test('adding functions', function () {
+  var person = {
+    name: 'Amory Blaine',
+    age: 102,
+    toString: function () {
+        return __;  // HINT: use the 'this' keyword to refer to the person object.
+      },
+  };
+
+  equal('I Amory Blaine am 102 years old.', person.toString(),
+    'what should the toString function be?');
 });

--- a/topics/about_objects.js
+++ b/topics/about_objects.js
@@ -40,7 +40,7 @@ test('adding functions', function () {
     age: 102,
     toString: function () {
         return __;  // HINT: use the 'this' keyword to refer to the person object.
-      },
+    },
   };
 
   equal('I Amory Blaine am 102 years old.', person.toString(),

--- a/topics/about_operators.js
+++ b/topics/about_operators.js
@@ -1,47 +1,54 @@
+module('About Operators (topics/about_operators.js)');
 
-module("About Operators (topics/about_operators.js)");
-
-test("addition", function() {
+test('addition', function () {
   var result = 0;
-  //starting i at 0, add i to result and increment i by 1 until i is equal to 5
+
+  // starting i at 0, add i to result and increment i by 1 until i is equal to 5
   for (var i = 0; i <= 5; i++) {
     result = result + i;
   }
-  equal(__, result, "What is the value of result?");
+
+  equal(__, result, 'What is the value of result?');
 });
 
-test("assignment addition", function() {
+test('assignment addition', function () {
   var result = 0;
-  for (var i = 0; i <=5; i++) {
-    //the code below is just like saying result = result + i; but is more concise
+  for (var i = 0; i <= 5; i++) {
+
+    // the code below is just like saying result = result + i; but is more concise
     result += i;
   }
-  equal(__, result, "What is the value of result?");
+
+  equal(__, result, 'What is the value of result?');
 });
 
-test("subtraction", function() {
+test('subtraction', function () {
   var result = 5;
   for (var i = 0; i <= 2; i++) {
     result = result - i;
   }
-  equal(__, result, "What is the value of result?");
+
+  equal(__, result, 'What is the value of result?');
 });
 
-test("assignment subtraction", function() {
+test('assignment subtraction', function () {
   var result = 5;
   for (var i = 0; i <= 2; i++) {
     result -= i;
   }
-  equal(__, result, "What is the value of result?");
+
+  equal(__, result, 'What is the value of result?');
 });
 
-//Assignment operators are available for multiplication and division as well
-//let's do one more, the modulo operator, used for showing division remainder
+// assignment operators are available for multiplication and division as well
+// let's do one more, the modulo operator, used for showing division remainder
 
-test("modulus", function() {
+test('modulus', function () {
   var result = 10;
   var x = 5;
-  //again this is exactly the same as result = result % x
+
+  // again this is exactly the same as result = result % x
   result %= x;
-  equal(__, result, "What is the value of result?");
+
+  equal(__, result, 'What is the value of result?');
 });

--- a/topics/about_prototypal_inheritance.js
+++ b/topics/about_prototypal_inheritance.js
@@ -59,6 +59,7 @@ extend(Bat, Mammal);
 
 test('Inheritance', function () {
   var lenny = new Bat('Lenny', '1.5m');
+
   equal(__, lenny.sayHi(), 'what does Lenny say?');
   equal(__, lenny.wingspan, "what is Lenny's wingspan?");
 });

--- a/topics/about_prototypal_inheritance.js
+++ b/topics/about_prototypal_inheritance.js
@@ -1,61 +1,64 @@
-
-// demonstrate the effect of modifying an objects prototype before and after the object is constructed
-
-module("About Prototypal Inheritance (topics/about_prototypal_inheritance.js)");
+module('About Prototypal Inheritance (topics/about_prototypal_inheritance.js)');
+// demonstrate the effect of modifying an objects prototype before and after the object
+// is constructed
 
 // this 'class' pattern defines a class by its constructor
-var Mammal = function(name) {
-    this.name = name;
-}
-// things that don't need to be set in the constructor should be added to the constructor's prototype property.
-Mammal.prototype = {
-    sayHi: function() {
-        return "Hello, my name is " + this.name;
-    }
-}
+var Mammal = function (name) {
+  this.name = name;
+};
 
-test("defining a 'class'", function() {
-    var eric  = new Mammal("Eric");
-    equal(__, eric.sayHi(), 'what will Eric say?');
+// things that don't need to be set in the constructor should be added to
+// the constructor's prototype property.
+Mammal.prototype = {
+  sayHi: function () {
+    return 'Hello, my name is ' + this.name;
+  },
+};
+
+test("defining a 'class'", function () {
+  var eric = new Mammal('Eric');
+  equal(__, eric.sayHi(), 'what will Eric say?');
 });
 
 // add another function to the Mammal 'type' that uses the sayHi function
-Mammal.prototype.favouriteSaying = function() {
-    return this.name + "'s favourite saying is " + this.sayHi(); 
-}
+Mammal.prototype.favouriteSaying = function () {
+  return this.name + "'s favourite saying is " + this.sayHi();
+};
 
-test("more functions", function() {
-    var bobby = new Mammal("Bobby");
-    equal(__, bobby.favouriteSaying(), "what is Bobby's favourite saying?"); 
+test('more functions', function () {
+  var bobby = new Mammal('Bobby');
+
+  equal(__, bobby.favouriteSaying(), "what is Bobby's favourite saying?");
 });
 
-test("calling functions added to a prototype after an object was created", function() {
-    var paul = new Mammal("Paul");
-    Mammal.prototype.numberOfLettersInName = function() {
-        return this.name.length;
-    };
-    // the following statement asks the paul object to call a function that was added
-    // to the Mammal prototype after paul was constructed.
-    equal(__, paul.numberOfLettersInName(), "how long is Paul's name?");
+test('calling functions added to a prototype after an object was created', function () {
+  var paul = new Mammal('Paul');
+  Mammal.prototype.numberOfLettersInName = function () {
+    return this.name.length;
+  };
+
+  // the following statement asks the paul object to call a function that was added
+  // to the Mammal prototype after paul was constructed.
+  equal(__, paul.numberOfLettersInName(), "how long is Paul's name?");
 });
 
-// helper function for inheritance. 
+// helper function for inheritance.
 // From https://developer.mozilla.org/en/JavaScript/Guide/Inheritance_Revisited
-function extend(child, supertype){  
-    child.prototype = supertype.prototype;  
-} 
+function extend(child, supertype) {
+  child.prototype = supertype.prototype;
+}
 
 // "Subclass" Mammal
 function Bat(name, wingspan) {
-    Mammal.call(this, name);
-    this.wingspan = wingspan;
-}	
+  Mammal.call(this, name);
+  this.wingspan = wingspan;
+}
 
 // configure inheritance
 extend(Bat, Mammal);
 
-test("Inheritance", function() {
-    var lenny = new Bat("Lenny", "1.5m");
-    equal(__, lenny.sayHi(), "what does Lenny say?");
-    equal(__, lenny.wingspan, "what is Lenny's wingspan?");
+test('Inheritance', function () {
+  var lenny = new Bat('Lenny', '1.5m');
+  equal(__, lenny.sayHi(), 'what does Lenny say?');
+  equal(__, lenny.wingspan, "what is Lenny's wingspan?");
 });

--- a/topics/about_prototype_chain.js
+++ b/topics/about_prototype_chain.js
@@ -1,11 +1,10 @@
+module('About Prototype Chain (topics/about_prototype_chain.js)');
 // demonstrate objects prototype chain
-
 // https://developer.mozilla.org/en/JavaScript/Guide/Inheritance_and_the_prototype_chain
-module("About Prototype Chain (topics/about_prototype_chain.js)");
 
 var father = {
   b: 3,
-  c: 4
+  c: 4,
 };
 
 var child = Object.create(father);
@@ -41,7 +40,6 @@ test("If 'b' was removed, whats b value?", function () {
   equal(__, child.b, 'what is \'b\' value now?');
 });
 
-
 test("Is there a 'c' own property on child?", function () {
   equal(__, child.hasOwnProperty('c'), 'child.hasOwnProperty(\'c\')?');
 });
@@ -52,12 +50,9 @@ test("Is there a 'c' property on child?", function () {
   equal(__, child.c, 'what is the value of child.c?');
 });
 
-
 // Is there a 'd' own property on child? No, check its prototype
 // Is there a 'd' own property on child.[[Prototype]]? No, check it prototype
 // child.[[Prototype]].[[Prototype]] is null, stop searching, no property found, return...
 test("Is there an 'd' property on child?", function () {
   equal(__, child.d, 'what is the value of child.d?');
 });
-
-

--- a/topics/about_reflection.js
+++ b/topics/about_reflection.js
@@ -1,68 +1,73 @@
-module("About Reflection (topics/about_reflection.js)");
+module('About Reflection (topics/about_reflection.js)');
 
 function A() {
-    this.aprop = "A";
+  this.aprop = 'A';
 };
 
 function B() {
-    this.bprop = "B";
+  this.bprop = 'B';
 };
 
 B.prototype = new A();
 
-test("typeof", function() {
-    equal(__, typeof({}), 'what is the type of an empty object?');
-    equal(__, typeof('apple'), 'what is the type of a string?');
-    equal(__, typeof(-5), 'what is the type of -5?');
-    equal(__, typeof(false), 'what is the type of false?');
+test('typeof', function () {
+  equal(__, typeof ({}), 'what is the type of an empty object?');
+  equal(__, typeof ('apple'), 'what is the type of a string?');
+  equal(__, typeof (-5), 'what is the type of -5?');
+  equal(__, typeof (false), 'what is the type of false?');
 });
 
-test("property enumeration", function() {
-    var keys = [];
-    var values = [];
-    var person = {name: 'Amory Blaine', age: 102, unemployed: true};
-    for(var propertyName in person) {
-        keys.push(propertyName);
-        values.push(person[propertyName]);
+test('property enumeration', function () {
+  var keys = [];
+  var values = [];
+  var person = { name: 'Amory Blaine', age: 102, unemployed: true };
+  for (var propertyName in person) {
+    keys.push(propertyName);
+    values.push(person[propertyName]);
+  }
+
+  ok(keys.equalTo(['__', '__', '__']), 'what are the property names of the object?');
+  ok(values.equalTo(['__', __, __]), 'what are the property values of the object?');
+});
+
+test('hasOwnProperty', function () {
+  var b = new B();
+  var propertyName;
+
+  var keys = [];
+  for (propertyName in b) {
+    keys.push(propertyName);
+  }
+
+  equal(__, keys.length, 'how many elements are in the keys array?');
+  deepEqual([__, __], keys, 'what are the properties of the array?');
+
+  // hasOwnProperty returns true if the parameter is a property directly on the object,
+  // but not if it is a property accessible via the prototype chain.
+  var ownKeys = [];
+  for (propertyName in b) {
+    if (b.hasOwnProperty(propertyName)) {
+      ownKeys.push(propertyName);
     }
-    ok(keys.equalTo(['__','__','__']), 'what are the property names of the object?');
-    ok(values.equalTo(['__',__,__]), 'what are the property values of the object?');
+  }
+
+  equal(__, ownKeys.length, 'how many elements are in the ownKeys array?');
+  deepEqual([__], ownKeys, 'what are the own properties of the array?');
 });
 
-test("hasOwnProperty", function() {
-    var b = new B();
-    var propertyName;
+test('constructor property', function () {
+  var a = new A();
+  var b = new B();
 
-    var keys = [];
-    for (propertyName in b) {
-        keys.push(propertyName);
-    }
-    equal(__, keys.length, 'how many elements are in the keys array?');
-    deepEqual([__, __], keys, 'what are the properties of the array?');
-
-    // hasOwnProperty returns true if the parameter is a property directly on the object,
-    // but not if it is a property accessible via the prototype chain.
-    var ownKeys = [];
-    for(propertyName in b) {
-        if (b.hasOwnProperty(propertyName)) {
-            ownKeys.push(propertyName);
-        }
-    }
-    equal(__, ownKeys.length, 'how many elements are in the ownKeys array?');
-    deepEqual([__], ownKeys, 'what are the own properties of the array?');
+  equal(__, typeof (a.constructor), "what is the type of a's constructor?");
+  equal(__, a.constructor.name, "what is the name of a's constructor?");
+  equal(__, b.constructor.name, "what is the name of b's constructor?");
 });
 
-test("constructor property", function () {
-    var a = new A();
-    var b = new B();
-    equal(__, typeof(a.constructor), "what is the type of a's constructor?");
-    equal(__, a.constructor.name, "what is the name of a's constructor?");
-    equal(__, b.constructor.name, "what is the name of b's constructor?");
-});
+test('eval', function () {
+  // eval executes a string
+  var result = '';
+  eval("result = 'apple' + ' ' + 'pie'");
 
-test("eval", function() {
-    // eval executes a string
-    var result = "";
-    eval("result = 'apple' + ' ' + 'pie'");
-    equal(__, result, 'what is the value of result?');
+  equal(__, result, 'what is the value of result?');
 });

--- a/topics/about_regular_expressions.js
+++ b/topics/about_regular_expressions.js
@@ -1,31 +1,36 @@
+module('About Regular Expressions (topics/about_regular_expressions.js)');
 
-module("About Regular Expressions (topics/about_regular_expressions.js)");
+test('exec', function () {
+  var numberFinder = /(\d).*(\d)/;
+  var results = numberFinder.exec('what if 6 turned out to be 9?');
 
-test("exec", function() {
-    var numberFinder = /(\d).*(\d)/;
-    var results = numberFinder.exec("what if 6 turned out to be 9?");
-    ok(results.equalTo([__, __, __]), 'what is the value of results?');		
+  ok(results.equalTo([__, __, __]), 'what is the value of results?');
 });
 
-test("test", function() {
-    var containsSelect = /select/.test("  select * from users ");
-    equal(__, containsSelect, 'does the string provided contain "select"?');
+test('test', function () {
+  var containsSelect = /select/.test('select * from users ');
+
+  equal(__, containsSelect, 'does the string provided contain "select"?');
 });
 
-test("match", function() {
-    var matches = "what if 6 turned out to be 9?".match(/(\d)/g);
-    ok(matches.equalTo([__, __]), 'what is the value of matches?');
+test('match', function () {
+  var matches = 'what if 6 turned out to be 9?'.match(/(\d)/g);
+
+  ok(matches.equalTo([__, __]), 'what is the value of matches?');
 });
 
-test("replace", function() {
-    var pie = "apple pie".replace("apple", "strawberry");
-    equal(__, pie, 'what is the value of pie?');
+test('replace', function () {
+  var pie = 'apple pie'.replace('apple', 'strawberry');
 
-    pie = "what if 6 turned out to be 9?".replace(/\d/g, function(number) { // the second parameter can be a string or a function
-        var map = {'6': 'six','9': 'nine'};
-        return map[number];
-    });
-    equal(__, pie, 'what is the value of pie?');
+  equal(__, pie, 'what is the value of pie?');
+
+  // the second parameter can be a string or a function
+  pie = 'what if 6 turned out to be 9?'.replace(/\d/g, function (number) {
+    var map = { 6: 'six', 9: 'nine' };
+    return map[number];
+  });
+
+  equal(__, pie, 'what is the value of pie?');
 });
 
 // THE END

--- a/topics/about_scope.js
+++ b/topics/about_scope.js
@@ -12,6 +12,7 @@ test('variables declared inside of a function', function () {
   // this is a self-invoking function. Notice that it calls itself at the end ().
   (function () {
     var innerVariable = 'inner';
+
     equal(__, outerVariable, 'is outerVariable defined in this scope?');
     equal(__, innerVariable, 'is innerVariable defined in this scope?');
   })();

--- a/topics/about_scope.js
+++ b/topics/about_scope.js
@@ -1,21 +1,21 @@
-module("About Scope (topics/about_scope.js)");
+module('About Scope (topics/about_scope.js)');
 
 thisIsAGlobalVariable = 77;
 
-test("global variables", function() {
-    equal(__, thisIsAGlobalVariable, 'is thisIsAGlobalVariable defined in this scope?');
+test('global variables', function () {
+  equal(__, thisIsAGlobalVariable, 'is thisIsAGlobalVariable defined in this scope?');
 });
 
-test("variables declared inside of a function", function() {
-    var outerVariable = "outer";
+test('variables declared inside of a function', function () {
+  var outerVariable = 'outer';
 
-    // this is a self-invoking function. Notice that it calls itself at the end ().
-    (function() {
-        var innerVariable = "inner";
-        equal(__, outerVariable, 'is outerVariable defined in this scope?');
-        equal(__, innerVariable, 'is innerVariable defined in this scope?');
-    })();
-
+  // this is a self-invoking function. Notice that it calls itself at the end ().
+  (function () {
+    var innerVariable = 'inner';
     equal(__, outerVariable, 'is outerVariable defined in this scope?');
-    equal(__, typeof(innerVariable), 'is innerVariable defined in this scope?');
+    equal(__, innerVariable, 'is innerVariable defined in this scope?');
+  })();
+
+  equal(__, outerVariable, 'is outerVariable defined in this scope?');
+  equal(__, typeof (innerVariable), 'is innerVariable defined in this scope?');
 });

--- a/topics/about_strings.js
+++ b/topics/about_strings.js
@@ -1,34 +1,39 @@
+module('About Strings (topics/about_strings.js)');
 
-module("About Strings (topics/about_strings.js)");
+test('delimiters', function () {
+  var singleQuotedString = 'apple';
+  var doubleQuotedString = "apple";
 
-test("delimiters", function() {
-    var singleQuotedString = 'apple';
-    var doubleQuotedString = "apple";
-    equal(__, singleQuotedString === doubleQuotedString, 'are the two strings equal?');
+  equal(__, singleQuotedString === doubleQuotedString, 'are the two strings equal?');
 });
 
-test("concatenation", function() {
-    var fruit = "apple";
-    var dish = "pie";
-    equal(__, fruit + " " + dish, 'what is the value of fruit + " " + dish?');
+test('concatenation', function () {
+  var fruit = 'apple';
+  var dish = 'pie';
+
+  equal(__, fruit + ' ' + dish, 'what is the value of fruit + " " + dish?');
 });
 
-test("character Type", function() {
-    var characterType = typeof("Amory".charAt(1)); // typeof will be explained in about reflection
-    equal(__, characterType, 'Javascript has no character type');
+test('character Type', function () {
+  var characterType = typeof ('Amory'.charAt(1)); // typeof will be explained in about reflection
+
+  equal(__, characterType, 'Javascript has no character type');
 });
 
-test("escape character", function() {
-    var stringWithAnEscapedCharacter  = "\u0041pple";
-    equal(__, stringWithAnEscapedCharacter, 'what  is the value of stringWithAnEscapedCharacter?');
+test('escape character', function () {
+  var stringWithAnEscapedCharacter = '\u0041pple';
+
+  equal(__, stringWithAnEscapedCharacter, 'what is the value of stringWithAnEscapedCharacter?');
 });
 
-test("string.length", function() {
-    var fruit = "apple";
-    equal(__, fruit.length, 'what is the value of fruit.length?');
+test('string.length', function () {
+  var fruit = 'apple';
+
+  equal(__, fruit.length, 'what is the value of fruit.length?');
 });
 
-test("slice", function() {
-    var fruit = "apple pie";
-    equal(__, fruit.slice(0,5), 'what is the value of fruit.slice(0,5)?');
+test('slice', function () {
+  var fruit = 'apple pie';
+
+  equal(__, fruit.slice(0, 5), 'what is the value of fruit.slice(0,5)?');
 });

--- a/topics/about_this.js
+++ b/topics/about_this.js
@@ -1,44 +1,49 @@
-module("About this (topics/about_this.js)");
+module('About this (topics/about_this.js)');
 
 test("'this' inside a method", function () {
-	var person = {
-		name: 'bob',
-		intro: function () {
-			return "Hello, my name is " + this.__;
-		} 
-	}
-	equal(person.intro(), "Hello, my name is bob", "If an object has a method can you access properties inside it?");
+  var person = {
+    name: 'bob',
+    intro: function () {
+      return 'Hello, my name is ' + this.__;
+    },
+  };
+
+  equal(person.intro(), 'Hello, my name is bob',
+    'If an object has a method can you access properties inside it?');
 });
 
 test("'this' on unattached function", function () {
-	var person = {
-		globalName: 'bob',
-		intro: function () {
-			return "Hello, my name is " + this.globalName;
-		} 
-	}
+  var person = {
+    globalName: 'bob',
+    intro: function () {
+      return 'Hello, my name is ' + this.globalName;
+    },
+  };
 
-	var alias = person.intro;
-	
-	// if the function is not called as an object property 'this' is the global context 
-	// (window in a browser). This is an example. Please do not do this in practise.
-	window.__ = 'Peter';
-	equal(alias(), "Hello, my name is Peter", "What does 'this' refer to when it is not part of an object?");
+  var alias = person.intro;
+
+  // if the function is not called as an object property 'this' is the global context
+  // (window in a browser). This is an example. Please do not do this in practise.
+  window.__ = 'Peter';
+
+  equal(alias(), 'Hello, my name is Peter',
+    "What does 'this' refer to when it is not part of an object?");
 });
 
 test("'this' set explicitly", function () {
-	var person = {
-		name: 'bob',
-		intro: function () {
-			return "Hello, my name is " + this.name;
-		} 
-	}
+  var person = {
+    name: 'bob',
+    intro: function () {
+      return 'Hello, my name is ' + this.name;
+    },
+  };
 
-	// calling a function with 'call' lets us assign 'this' explicitly
-	var message = person.intro.call({__: "Frank"});
-	equal(message, "Hello, my name is Frank", "What does 'this' refer to when you use the 'call()' method?");
+  // calling a function with 'call' lets us assign 'this' explicitly
+  var message = person.intro.call({ __: 'Frank' });
+
+  equal(message, 'Hello, my name is Frank',
+    "What does 'this' refer to when you use the 'call()' method?");
 });
 
 // extra credit: underscore.js has a 'bind' function http://documentcloud.github.com/underscore/#bind
 // read the source and see how it is implemented
-

--- a/topics/about_truthyness.js
+++ b/topics/about_truthyness.js
@@ -1,22 +1,21 @@
+module('About Truthyness (topics/about_truthyness.js)');
 
-module("About Truthyness (topics/about_truthyness.js)");
-
-test("truthyness of positive numbers", function() {
-    var oneIsTruthy = 1 ? true : false;
-    equal(__, oneIsTruthy, 'is one truthy?');
+test('truthyness of positive numbers', function () {
+  var oneIsTruthy = 1 ? true : false;
+  equal(__, oneIsTruthy, 'is one truthy?');
 });
 
-test("truthyness of negative numbers", function() {
-    var negativeOneIsTruthy = -1 ? true : false;
-    equal(__, negativeOneIsTruthy, 'is -1 truthy?');
+test('truthyness of negative numbers', function () {
+  var negativeOneIsTruthy = -1 ? true : false;
+  equal(__, negativeOneIsTruthy, 'is -1 truthy?');
 });
 
-test("truthyness of zero", function() {
-    var zeroIsTruthy = 0 ? true : false;
-    equal(__, zeroIsTruthy, 'is 0 truthy?');
+test('truthyness of zero', function () {
+  var zeroIsTruthy = 0 ? true : false;
+  equal(__, zeroIsTruthy, 'is 0 truthy?');
 });
 
-test("truthyness of null", function() {
-    var nullIsTruthy = null ? true : false;
-    equal(__, nullIsTruthy, 'is null truthy?');
+test('truthyness of null', function () {
+  var nullIsTruthy = null ? true : false;
+  equal(__, nullIsTruthy, 'is null truthy?');
 });

--- a/topics/about_truthyness.js
+++ b/topics/about_truthyness.js
@@ -2,20 +2,24 @@ module('About Truthyness (topics/about_truthyness.js)');
 
 test('truthyness of positive numbers', function () {
   var oneIsTruthy = 1 ? true : false;
+
   equal(__, oneIsTruthy, 'is one truthy?');
 });
 
 test('truthyness of negative numbers', function () {
   var negativeOneIsTruthy = -1 ? true : false;
+
   equal(__, negativeOneIsTruthy, 'is -1 truthy?');
 });
 
 test('truthyness of zero', function () {
   var zeroIsTruthy = 0 ? true : false;
+
   equal(__, zeroIsTruthy, 'is 0 truthy?');
 });
 
 test('truthyness of null', function () {
   var nullIsTruthy = null ? true : false;
+
   equal(__, nullIsTruthy, 'is null truthy?');
 });


### PR DESCRIPTION
These changes attempt to fix some style inconsistencies and improve
readablity by running a linter using the widely adopted [airbnb javascript styleguide](https://github.com/airbnb/javascript)

[example lint output](https://github.com/liammclennan/JavaScript-Koans/files/606207/lint.txt)

Note: these changes preserve the double quotes in the appropriate
context

Changes aside from linter:
 * seperate assertions by newlines
 * replace erroneous double spaces with single
 * change comment formatting to improve readablity